### PR TITLE
Move to CryptoRandomGen from RandomGen

### DIFF
--- a/RSA.cabal
+++ b/RSA.cabal
@@ -32,7 +32,7 @@ Flag OldBase
   Default: False
 
 Library
- build-depends: bytestring, random
+ build-depends: bytestring, crypto-api >= 0.10, monadcryptorandom
  GHC-Options: -O2 -Wall -fno-ignore-asserts -fno-warn-orphans
  if flag(OldBase)
    build-depends: base >= 3 && < 4, SHA < 1.4.1
@@ -56,9 +56,10 @@ Executable test_rsa
       build-depends: base >= 3 && < 4, SHA < 1.4.1
     else
       build-depends: base >= 4 && < 5, SHA
-    build-depends: bytestring, test-framework >= 0.3 && < 0.4,
+    build-depends: bytestring, test-framework >= 0.3 && < 0.7,
                    QuickCheck >= 2 && < 3,
-                   test-framework-quickcheck2 >= 0.2 && < 0.3
+                   test-framework-quickcheck2 >= 0.2 && < 0.7,
+                   intel-aes
   else
     Buildable: False
   GHC-Options: -O2 -Wall -fno-ignore-asserts -fno-warn-orphans 


### PR DESCRIPTION
Move to CryptoRandomGen from RandomGen.

The tests were also updated and complete successfully on my machine.

This is a move to a class of generators intended for instantiation only
by cryptographically secure generators that allow for failure and reseed.
For RSA, failures are in the form of exceptions (of type GenError).

This patch has one semantic change besides the obvious
RandomGen->CryptoRandomGen replacement!  The rsaes_oaep_encrypt function was
accepting an integer seed in the range of +/-2^29 (or whatever Int size is on
the host) and translating it to a bytestring in the range of [0..2^29].  Thus,
we were getting only 4 or 8 bytes of entropy (maximum) for a 32 byte long
bytestring (assuming a default of SHA256).  It now accepts generators and will
generate random bytestrings of length equal to the size of the digest for the
provided hash algorithm.

I'm not sure what, if any, security implications this has - see RFC 3447 Sec
7.1.1 and see line 247 in RSA.hs (line 248 pre-patch, I think).
