### PR TITLE
Crypto pubkey types

### DIFF
--- a/RSA.cabal
+++ b/RSA.cabal
@@ -32,7 +32,7 @@ Flag OldBase
   Default: False
 
 Library
- build-depends: bytestring, crypto-api >= 0.10, monadcryptorandom
+ build-depends: bytestring, crypto-api >= 0.10, monadcryptorandom, crypto-pubkey-types
  GHC-Options: -O2 -Wall -fno-ignore-asserts -fno-warn-orphans
  if flag(OldBase)
    build-depends: base >= 3 && < 4, SHA < 1.4.1

--- a/Test.hs
+++ b/Test.hs
@@ -10,6 +10,7 @@ import Test.QuickCheck
 import Crypto.Random
 import Crypto.Random.DRBG
 import Crypto.Types
+import Crypto.Types.PubKey.RSA
 
 import Test.Framework (defaultMain, testGroup, Test)
 import Test.Framework.Providers.QuickCheck2 (testProperty)


### PR DESCRIPTION
This is a set of changes to use the RSA PublicKey / PrivateKey definitions from the crypto-pubkey-types package for improved interoperability with other crypto and certificate modules.

I converted `Int64` to `Int` with `fromIntegral` where necessary and changed type signatures where required to accept `Int` instead of `Int64` (public_size/private_size are `Int`s, not `Int64` in crypto-pubkey-types).

It would probably be cleaner to replace all instances of `Int64` with `Int`, but I think that this change set is less problematic. The test suite passes. (Previous problems with the test suite were a consequence of a bug in `monadcryptorandom`  which has meanwhile been fixed.)
