### PR TITLE
Build on GHC 8.8

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -98,10 +98,10 @@ instance Arbitrary LargePrime where
   arbitrary =
     do seed <- BSS.pack `fmap` replicateM 4096 arbitrary
        case newGen seed of
-        Left _ -> fail "DRBG initialization error."
+        Left _ -> error "DRBG initialization error."
         Right (g :: HashDRBG) ->
           case largeRandomPrime g 64 of
-            Left _ -> fail "Large prime generation failure."
+            Left _ -> error "Large prime generation failure."
             Right (i, _) -> return (LP i)
 
 data KeyPairIdx = KPI Int

--- a/src/Codec/Crypto/RSA/Pure.hs
+++ b/src/Codec/Crypto/RSA/Pure.hs
@@ -111,7 +111,7 @@ instance Binary PrivateKey where
               d   <- os2ip `fmap` getLazyByteString (fromIntegral (public_size pub))
               return (PrivateKey pub d 0 0 0 0 0)
 
-failOnError :: (Monad m, Show a) => Either a b -> m b
+failOnError :: (MonadFail m, Show a) => Either a b -> m b
 failOnError (Left e)  = fail (show e)
 failOnError (Right b) = return b
 

--- a/src/Codec/Crypto/RSA/Pure.hs
+++ b/src/Codec/Crypto/RSA/Pure.hs
@@ -111,8 +111,8 @@ instance Binary PrivateKey where
               d   <- os2ip `fmap` getLazyByteString (fromIntegral (public_size pub))
               return (PrivateKey pub d 0 0 0 0 0)
 
-failOnError :: (MonadFail m, Show a) => Either a b -> m b
-failOnError (Left e)  = fail (show e)
+failOnError :: (Monad m, Show a) => Either a b -> m b
+failOnError (Left e)  = error (show e)
 failOnError (Right b) = return b
 
 -- ----------------------------------------------------------------------------


### PR DESCRIPTION
The use of `fail` requires `MonadFail` on GHC 8.8, but the monads it's being used in don't even have those instances. `error` is our only real option.