### PR TITLE
Use crypton-pubkey-types instead of crypto-pubkey-types.

### DIFF
--- a/RSA.cabal
+++ b/RSA.cabal
@@ -8,25 +8,35 @@ maintainer: Adam Wick <awick@galois.com>
 stability:  stable
 build-type: Simple
 cabal-version: >= 1.8
-tested-with: GHC ==7.8.0
+tested-with: GHC ==7.8.0 || ==9.14.1
 synopsis: Implementation of RSA, using the padding schemes of PKCS#1 v2.1.
-description: This library implements the RSA encryption and signature 
-             algorithms for arbitrarily-sized ByteStrings. While the 
+description: This library implements the RSA encryption and signature
+             algorithms for arbitrarily-sized ByteStrings. While the
              implementations work, they are not necessarily the fastest ones
              on the planet. Particularly key generation. The algorithms
              included are based of RFC 3447, or the Public-Key Cryptography
-             Standard for RSA, version 2.1 (a.k.a, PKCS#1 v2.1).   
+             Standard for RSA, version 2.1 (a.k.a, PKCS#1 v2.1).
+
+flag use-crypton-pubkey-types
+  description: Use the package crypton-pubkey-types the fork of crypto-pubkey-types
+  manual: False
+  default: True
 
 Library
   hs-source-dirs:  src
   build-depends:   base                >= 4.6     && < 7.0,
                    binary              >  0.7     && < 1.0,
-                   bytestring          >  0.8     && < 0.12,
+                   bytestring          >  0.8     && < 0.13,
                    crypto-api          >= 0.10    && < 0.14,
-                   crypto-pubkey-types >= 0.2     && < 0.6,
                    SHA                 >= 1.6.4.1 && < 2.0
+  if flag(use-crypton-pubkey-types)
+    build-depends:
+                   crypton-pubkey-types >= 0.5     && < 0.6
+  else
+    build-depends:
+                   crypto-pubkey-types >= 0.2      && < 0.5
   if impl(ghc < 8.0)
-    build-depends: cipher-aes128       < 0.7.0.4
+    build-depends: cipher-aes128       < 0.7.0.7
   exposed-modules: Codec.Crypto.RSA,
                    Codec.Crypto.RSA.Exceptions,
                    Codec.Crypto.RSA.Pure
@@ -40,7 +50,7 @@ test-suite test-rsa
   other-modules:  Codec.Crypto.RSA.Pure
   build-depends:  base                       >= 4.6     && < 7.0,
                   binary                     >  0.7     && < 1.0,
-                  bytestring                 >  0.8     && < 0.12,
+                  bytestring                 >  0.8     && < 0.13,
                   crypto-api                 >= 0.10    && < 0.14,
                   crypto-pubkey-types        >= 0.4     && < 0.6,
                   HUnit                      >= 1.2     && < 1.7,
@@ -55,5 +65,4 @@ test-suite test-rsa
 
 source-repository head
   type: git
-  location: git://github.com/GaloisInc/RSA.git
-
+  location: https://github.com/GaloisInc/RSA.git


### PR DESCRIPTION
The former brings memory in its dependency closure which is no longer maintained.

[crypton-pubkey-types](https://hackage.haskell.org/package/crypton-pubkey-types) is a new fork I created that uses forked version of `asn1-*` packages which are all unmaintained now along with rest of the `cryptonite` universe.

I also bumped upper bounds of some dependencies.